### PR TITLE
fix display property to enable badges

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1269,7 +1269,7 @@ td.poster-names a {
   }
 
   //show badges
-  .badge-card .badge-contents .badge-icon,
+  .badge-card .badge-contents .badge-icon svg,
   .user-menu .quick-access-panel li .d-icon {
     display: flex;
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1268,7 +1268,7 @@ td.poster-names a {
     display: inline-flex $i;
   }
 
-  //remove badges
+  //show badges
   .badge-card .badge-contents .badge-icon,
   .user-menu .quick-access-panel li .d-icon {
     display: flex;

--- a/common/common.scss
+++ b/common/common.scss
@@ -1271,7 +1271,7 @@ td.poster-names a {
   //remove badges
   .badge-card .badge-contents .badge-icon,
   .user-menu .quick-access-panel li .d-icon {
-    display: none;
+    display: flex;
   }
 
   //mobile view

--- a/common/common.scss
+++ b/common/common.scss
@@ -1268,7 +1268,7 @@ td.poster-names a {
     display: inline-flex $i;
   }
 
-  //show badges
+  // icon display exceptions for badges
   .badge-card .badge-contents .badge-icon svg,
   .user-menu .quick-access-panel li .d-icon svg{
     display: flex $i;

--- a/common/common.scss
+++ b/common/common.scss
@@ -1271,7 +1271,7 @@ td.poster-names a {
   //show badges
   .badge-card .badge-contents .badge-icon svg,
   .user-menu .quick-access-panel li .d-icon svg{
-    display: flex;
+    display: flex $i;
   }
 
   //mobile view

--- a/common/common.scss
+++ b/common/common.scss
@@ -1270,7 +1270,7 @@ td.poster-names a {
 
   //show badges
   .badge-card .badge-contents .badge-icon svg,
-  .user-menu .quick-access-panel li .d-icon {
+  .user-menu .quick-access-panel li .d-icon svg{
     display: flex;
   }
 


### PR DESCRIPTION
Enabling the badges by changing the display css property from `none` to `flex`

Closes [#38265](https://github.com/freeCodeCamp/freeCodeCamp/issues/38265) issue on the [main repository](https://github.com/freeCodeCamp/freeCodeCamp)